### PR TITLE
Added a way to create Julian dates using datetime objects.

### DIFF
--- a/sgp4/ext.py
+++ b/sgp4/ext.py
@@ -470,17 +470,23 @@ def rv2coe(r, v, mu):
 * --------------------------------------------------------------------------- */
 """
 
-def jday(
-          year, mon, day, hr, minute, sec,
-        ):
+def jday(date):
+    if isinstance(date, datetime.datetime):
+        year, mon, day, hr, minute, sec = date.year, date.month, date.day, date.hour, date.minute, date.second
+    elif isinstance(date, list):
+        year, mon, day, hr, minute, sec = date[0], date[1], date[2], date[3], date[4], date[5]
+    else:
+        raise TypeError('jday requires either a datetime object'
+                        ' or a list of integers of the following form:'
+                        ' [year, month, day, hour, minute, second]')
 
-  return (367.0 * year -
-          floor((7 * (year + floor((mon + 9) / 12.0))) * 0.25) +
-          floor( 275 * mon / 9.0 ) +
-          day + 1721013.5 +
-          ((sec / 60.0 + minute) / 60.0 + hr) / 24.0  #  ut in days
-          #  - 0.5*sgn(100.0*year + mon - 190002.5) + 0.5;
-          )
+    return (367.0 * year -
+            floor((7 * (year + floor((mon + 9) / 12.0))) * 0.25) +
+            floor( 275 * mon / 9.0 ) +
+            day + 1721013.5 +
+            ((sec / 60.0 + minute) / 60.0 + hr) / 24.0  #  ut in days
+            #  - 0.5*sgn(100.0*year + mon - 190002.5) + 0.5;
+            )
 
 """
 /* -----------------------------------------------------------------------------

--- a/sgp4/io.py
+++ b/sgp4/io.py
@@ -18,8 +18,8 @@ FLOAT_RE = re.compile(r'[+-]?\d*(\.\d*)?')
 *
 *                               sgp4io.cpp
 *
-*    this file contains a function to read two line element sets. while 
-*    not formerly part of the sgp4 mathematical theory, it is 
+*    this file contains a function to read two line element sets. while
+*    not formerly part of the sgp4 mathematical theory, it is
 *    required for practical implemenation.
 *
 *                            companion code for
@@ -65,7 +65,7 @@ FLOAT_RE = re.compile(r'[+-]?\d*(\.\d*)?')
 *  inputs        :
 *    longstr1    - first line of the tle
 *    longstr2    - second line of the tle
-*    typerun     - type of run                    verification 'v', catalog 'c', 
+*    typerun     - type of run                    verification 'v', catalog 'c',
 *                                                 manual 'm'
 *    typeinput   - type of manual input           mfe 'm', epoch 'e', dayofyr 'd'
 *    opsmode     - mode of operation afspc or improved 'a', 'i'
@@ -211,7 +211,7 @@ def twoline2rv(longstr1, longstr2, whichconst, afspc_mode=False):
            year= satrec.epochyr + 1900;
 
        mon,day,hr,minute,sec = days2mdhms(year, satrec.epochdays);
-       satrec.jdsatepoch = jday(year,mon,day,hr,minute,sec);
+       satrec.jdsatepoch = jday([year, mon, day, hr, minute, sec]);
 
        #  ---------------- initialize the orbit at sgp4epoch -------------------
        sgp4init( whichconst, opsmode, satrec.satnum, satrec.jdsatepoch-2433281.5, satrec.bstar,

--- a/sgp4/model.py
+++ b/sgp4/model.py
@@ -44,7 +44,7 @@ class Satellite(object):
     def propagate(self, year, month=1, day=1, hour=0, minute=0, second=0.0):
         """Return a position and velocity vector for a given date and time."""
 
-        j = jday(year, month, day, hour, minute, second)
+        j = jday([year, month, day, hour, minute, second])
         m = (j - self.jdsatepoch) * minutes_per_day
         r, v = sgp4(self, m)
         return r, v


### PR DESCRIPTION
Modified the jday function to accept either a datetime object or
a list of variables representing year, month, day, hour, minute, second; as before.

While making the old way a bit more of a hassle, datetime objects can more conveniently
be played around with and modified with such tools as timedelta.
