### PR TITLE
Fix final computation of eo1 trig functions in sgp4()

### DIFF
--- a/sgp4/propagation.py
+++ b/sgp4/propagation.py
@@ -1821,6 +1821,10 @@ def sgp4(satrec, tsince, whichconst=None):
          eo1    = eo1 + tem5;
          ktr = ktr + 1;
 
+     # Recompute sine/cosine values after the iteration converges
+     sineo1 = sin(eo1);
+     coseo1 = cos(eo1);
+
      #  ------------- short period preliminary quantities -----------
      ecose = axnl*coseo1 + aynl*sineo1;
      esine = axnl*sineo1 - aynl*coseo1;


### PR DESCRIPTION
Hello,

The attached patch recomputes `sineo1` and `coseo1` after the kepler iteration converges in `sgp4()` -- previously they weren't being recomputed.  This should make almost no difference, but recomputing after the iteration has converged seems to be what the original FORTRAN code does.  See page 8 of [SpaceTrack Report No. 3](http://www.celestrak.com/NORAD/documentation/spacetrk.pdf) -- this is in the `SGP` subroutine; the iteration in the `SGP4` subroutine given on page 18 that report is different from what this library does.
