### PR TITLE
Checking for a min length of TLE

### DIFF
--- a/sgp4/io.py
+++ b/sgp4/io.py
@@ -12,7 +12,7 @@ from sgp4.propagation import sgp4init
 
 INT_RE = re.compile(r'[+-]?\d*')
 FLOAT_RE = re.compile(r'[+-]?\d*(\.\d*)?')
-
+TLE_LENGTH = 69
 
 """
 /*     ----------------------------------------------------------------
@@ -87,6 +87,12 @@ FLOAT_RE = re.compile(r'[+-]?\d*(\.\d*)?')
   --------------------------------------------------------------------------- */
 """
 
+def tle_list_maker(raw_tle_str):
+    tle_list = [c for c in raw_tle_str]
+    if len(tle_list) < TLE_LENGTH:
+        raise Exception('TLE line length was not %s chars long (was %s char long)' % (TLE_LENGTH, len(tle_list)))
+    return tle_list
+
 def twoline2rv(longstr1, longstr2, whichconst, afspc_mode=False):
        """Return a Satellite imported from two lines of TLE data.
 
@@ -119,8 +125,9 @@ def twoline2rv(longstr1, longstr2, whichconst, afspc_mode=False):
 
        # This is Python, so we convert the strings into mutable lists of
        # characters before setting the C++ code loose on them.
-       longstr1 = [ c for c in longstr1 ]
-       longstr2 = [ c for c in longstr2 ]
+       longstr1 = tle_list_maker(longstr1)
+       longstr2 = tle_list_maker(longstr2)
+
 
        #  set the implied decimal points since doing a formated read
        #  fixes for bad input data values (missing, ...)

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -8,7 +8,7 @@ from math import pi, isnan
 
 from sgp4.earth_gravity import wgs72
 from sgp4.ext import invjday, newtonnu, rv2coe
-from sgp4.io import twoline2rv
+from sgp4.io import twoline2rv, tle_list_maker
 from sgp4.propagation import sgp4
 
 thisdir = os.path.dirname(__file__)
@@ -17,6 +17,13 @@ rad = 180.0 / pi
 
 
 class Tests(TestCase):
+
+    def test_tle_list_maker(self):
+        line1 = "012345678901234567890123456789012345678901234567890123457890123456890"
+        try:
+            tle_list_maker(line1)
+        except Exception:
+            self.fail("Test did not see normal length line")
 
     def test_tle_verify(self):
         # Check whether a test run produces the output in tcppver.out

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -30,7 +30,7 @@ class Tests(TestCase):
         try:
             tle_list_maker(line1)
         except Exception as e:
-            self.assertEquals("TLE line length was not 69 chars long (was 64 char long)", e.message)
+            self.assertEquals("TLE line length was not 69 chars long (was 64 char long)", str(e))
             return
         self.fail("Test did not see the short length line")
 

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -25,6 +25,15 @@ class Tests(TestCase):
         except Exception:
             self.fail("Test did not see normal length line")
 
+    def test_tle_list_maker_short(self):
+        line1 = "0123456789012345678901234567890123456789012345678901234578901234"
+        try:
+            tle_list_maker(line1)
+        except Exception as e:
+            self.assertEquals("TLE line length was not 69 chars long (was 64 char long)", e.message)
+            return
+        self.fail("Test did not see the short length line")
+
     def test_tle_verify(self):
         # Check whether a test run produces the output in tcppver.out
 

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -27,12 +27,14 @@ class Tests(TestCase):
 
     def test_tle_list_maker_short(self):
         line1 = "0123456789012345678901234567890123456789012345678901234578901234"
-        try:
-            tle_list_maker(line1)
-        except Exception as e:
-            self.assertEquals("TLE line length was not 69 chars long (was 64 char long)", str(e))
-            return
-        self.fail("Test did not see the short length line")
+        if sys.version_info >= (2, 7):
+            self.assertRaisesRegexp(
+                Exception,
+                "TLE line length was not 69 chars long \(was 64 char long\)",
+                tle_list_maker,
+                line1)
+        else:
+            self.assertRaises(Exception, tle_list_maker, line1)
 
     def test_tle_verify(self):
         # Check whether a test run produces the output in tcppver.out


### PR DESCRIPTION
A TLE is expected to be 69 characters long. This code will take a string, turn it into a list of chars, and make sure it is at least 69 chars.
Longer lines are possible, but only in the test data located in SGP4-VER.TLE

This is for issue #5 