### PR TITLE
Numba jit

### DIFF
--- a/sgp4/io.py
+++ b/sgp4/io.py
@@ -81,7 +81,7 @@ with an N where each digit should go, followed by the line you provided:
 *    typerun     - type of run                    verification 'v', catalog 'c', 
 *                                                 manual 'm'
 *    typeinput   - type of manual input           mfe 'm', epoch 'e', dayofyr 'd'
-*    opsmode     - mode of operation afspc or improved 'a', 'i'
+*    afspc_mode  - True for afspc calculations, False for 'improved' mode
 *    whichconst  - which set of constants to use  72, 84
 *
 *  outputs       :
@@ -115,7 +115,6 @@ def twoline2rv(longstr1, longstr2, whichconst, afspc_mode=False):
     back into "afspc" mode, then set `afspc_mode` to `True`.
 
     """
-    opsmode = 'a' if afspc_mode else 'i'
 
     deg2rad  =   pi / 180.0;         #    0.0174532925199433
     xpdotp   =  1440.0 / (2.0 *pi);  #  229.1831180523293
@@ -219,7 +218,7 @@ def twoline2rv(longstr1, longstr2, whichconst, afspc_mode=False):
                             int(sec_fraction * 1000000.0 // 1.0))
 
     #  ---------------- initialize the orbit at sgp4epoch -------------------
-    sgp4init(whichconst, opsmode, satrec.satnum, satrec.jdsatepoch-2433281.5, satrec.bstar,
+    sgp4init(whichconst, afspc_mode, satrec.satnum, satrec.jdsatepoch-2433281.5, satrec.bstar,
              satrec.ecco, satrec.argpo, satrec.inclo, satrec.mo, satrec.no,
              satrec.nodeo, satrec)
 

--- a/sgp4/io.py
+++ b/sgp4/io.py
@@ -126,53 +126,61 @@ def twoline2rv(longstr1, longstr2, whichconst, afspc_mode=False):
     satrec.whichconst = whichconst  # Python extension: remembers its consts
 
     line = longstr1.rstrip()
-    try:
-        assert line.startswith('1 ')
-        satrec.satnum = int(line[2:7])
+    # try/except is not well supported by Numba
+    if (len(line) >= 64 and
+        line.startswith('1 ') and
+        line[8] == ' ' and
+        line[23] == '.' and
+        line[32] == ' ' and
+        line[34] == '.' and
+        line[43] == ' ' and
+        line[52] == ' ' and
+        line[61] == ' ' and
+        line[63] == ' '):
+
+        _saved_satnum = satrec.satnum = int(line[2:7])
         # classification = line[7] or 'U'
-        assert line[8] == ' '
         # intldesg = line[9:17]
         two_digit_year = int(line[18:20])
-        assert line[23] == '.'
         satrec.epochdays = float(line[20:32])
-        assert line[32] == ' '
-        assert line[34] == '.'
         satrec.ndot = float(line[33:43])
-        assert line[43] == ' '
         satrec.nddot = float(line[44] + '.' + line[45:50])
         nexp = int(line[50:52])
-        assert line[52] == ' '
         satrec.bstar = float(line[53] + '.' + line[54:59])
         ibexp = int(line[59:61])
-        assert line[61] == ' '
-        assert line[63] == ' '
         # numb = int(line[62])
         # elnum = int(line[64:68])
-    except (AssertionError, IndexError, ValueError):
+    else:
         raise ValueError(error_message.format(1, LINE1, line))
 
     line = longstr2.rstrip()
-    try:
-        assert line.startswith('2 ')
-        satrec.satnum = int(line[2:7])  # TODO: check it matches line 1?
-        assert line[7] == ' '
-        assert line[11] == '.'
+    line_format_ok = False
+    if (len(line) >= 69 and
+        line.startswith('2 ') and
+        line[7] == ' ' and
+        line[11] == '.' and
+        line[16] == ' ' and
+        line[20] == '.' and
+        line[25] == ' ' and
+        line[33] == ' ' and
+        line[37] == '.' and
+        line[42] == ' ' and
+        line[46] == '.' and
+        line[51] == ' '):
+
+        satrec.satnum = int(line[2:7])
+        if _saved_satnum != satrec.satnum:
+            raise ValueError('Object numbers in lines 1 and 2 do not match')
+
         satrec.inclo = float(line[8:16])
-        assert line[16] == ' '
-        assert line[20] == '.'
         satrec.nodeo = float(line[17:25])
-        assert line[25] == ' '
         satrec.ecco = float('0.' + line[26:33].replace(' ', '0'))
-        assert line[33] == ' '
-        assert line[37] == '.'
         satrec.argpo = float(line[34:42])
-        assert line[42] == ' '
-        assert line[46] == '.'
         satrec.mo = float(line[43:51])
-        assert line[51] == ' '
         satrec.no = float(line[52:63])
         #revnum = line[63:68]
-    except (AssertionError, IndexError, ValueError):
+    #except (AssertionError, IndexError, ValueError):
+    else:
         raise ValueError(error_message.format(2, LINE2, line))
 
     #  ---- find no, ndot, nddot ----

--- a/sgp4/propagation.py
+++ b/sgp4/propagation.py
@@ -147,7 +147,7 @@ twopi = 2.0 * pi
   ----------------------------------------------------------------------------*/
 """
 
-def _dpper(satrec, inclo, init, ep, inclp, nodep, argpp, mp, opsmode):
+def _dpper(satrec, inclo, init, ep, inclp, nodep, argpp, mp, afspc_mode):
 
      # Copy satellite attributes into local variables for convenience
      # and symmetry in writing formulae.
@@ -269,14 +269,14 @@ def _dpper(satrec, inclo, init, ep, inclp, nodep, argpp, mp, opsmode):
            nodep  = fmod(nodep, twopi);
            #   sgp4fix for afspc written intrinsic functions
            #  nodep used without a trigonometric function ahead
-           if nodep < 0.0 and opsmode == 'a':
+           if nodep < 0.0 and afspc_mode:
                nodep = nodep + twopi;
            xls = mp + argpp + pl + pgh + (cosip - pinc * sinip) * nodep
            xnoh   = nodep;
            nodep  = atan2(alfdp, betdp);
            #   sgp4fix for afspc written intrinsic functions
            #  nodep used without a trigonometric function ahead
-           if nodep < 0.0 and opsmode == 'a':
+           if nodep < 0.0 and afspc_mode:
                nodep = nodep + twopi;
            if fabs(xnoh - nodep) > pi:
              if nodep < xnoh:
@@ -1123,7 +1123,7 @@ def _initl(
        satn,      whichconst,
        ecco,   epoch,  inclo,   no,
        method,
-       opsmode,
+       afspc_mode,
        ):
 
      # sgp4fix use old way of finding gst
@@ -1160,7 +1160,7 @@ def _initl(
      method = 'n';
 
      #  sgp4fix modern approach to finding sidereal time
-     if opsmode == 'a':
+     if afspc_mode:
 
          #  sgp4fix use old way of finding gst
          #  count integer number of days from 0 jan 1970
@@ -1197,7 +1197,7 @@ def _initl(
 *  author        : david vallado                  719-573-2600   28 jun 2005
 *
 *  inputs        :
-*    opsmode     - mode of operation afspc or improved 'a', 'i'
+*    afspc_mode  - use afspc or improved mode of operation
 *    whichconst  - which set of constants to use  72, 84
 *    satn        - satellite number
 *    bstar       - sgp4 type drag coefficient              kg/m2er
@@ -1272,7 +1272,7 @@ def _initl(
 """
 
 def sgp4init(
-       whichconst, opsmode,   satn,     epoch,
+       whichconst, afspc_mode,   satn,     epoch,
        xbstar,  xecco, xargpo,
        xinclo,  xmo,   xno,
        xnodeo,  satrec,
@@ -1333,7 +1333,7 @@ def sgp4init(
      satrec.nodeo   = xnodeo;
 
      #  sgp4fix add opsmode
-     satrec.operationmode = opsmode;
+     satrec.afspc_mode = afspc_mode;
 
      #  ------------------------ earth constants -----------------------
      #  sgp4fix identify constants and allow alternate values
@@ -1355,7 +1355,7 @@ def sgp4init(
        rp,    rteosq,sinio , satrec.gsto,
        ) = _initl(
            satn, whichconst, satrec.ecco, epoch, satrec.inclo, satrec.no, satrec.method,
-           satrec.operationmode
+           satrec.afspc_mode
          );
      satrec.error = 0;
 
@@ -1490,7 +1490,7 @@ def sgp4init(
               ) = _dpper(
                    satrec, inclm, satrec.init,
                    satrec.ecco, satrec.inclo, satrec.nodeo, satrec.argpo, satrec.mo,
-                   satrec.operationmode
+                   satrec.afspc_mode
                  );
 
              argpm  = 0.0;
@@ -1773,7 +1773,7 @@ def sgp4(satrec, tsince, whichconst=None):
 
          ep, xincp, nodep, argpp, mp = _dpper(
                satrec, satrec.inclo,
-               'n', ep, xincp, nodep, argpp, mp, satrec.operationmode
+               'n', ep, xincp, nodep, argpp, mp, satrec.afspc_mode
              );
          if xincp < 0.0:
 

--- a/sgp4/propagation.py
+++ b/sgp4/propagation.py
@@ -17,6 +17,19 @@ code for the first time here in its Python form.
 |   On a very hot August day in 2012
 """
 
+try:
+     from numba import jit
+except ImportError:
+     def jit(jit_this=None, **jit_options):
+          if jit_this is not None:
+               def fake_jit(*args, **kwargs):
+                    return jit_this(*args, **kwargs)
+               return fake_jit
+          else:
+               def partial_fake_jit(jit_this, **jit_options):
+                    return jit(jit_this, **jit_options)
+               return partial_fake_jit
+
 from math import atan2, cos, fabs, fmod, pi, sin, sqrt
 
 deg2rad = pi / 180.0;
@@ -928,6 +941,8 @@ def _dsinit(
   ----------------------------------------------------------------------------*/
 """
 
+@jit(cache=True)
+#@jit
 def _dspace(
        irez,
        d2201,  d2211,  d3210,   d3222,  d4410,
@@ -1642,6 +1657,8 @@ def sgp4init(
   ----------------------------------------------------------------------------*/
 """
 
+@jit(cache=True)
+#@jit
 def sgp4(satrec, tsince, whichconst=None):
 
      mrt = 0.0

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -153,9 +153,14 @@ with an N where each digit should go, followed by the line you provided:
 2 00005 34 .268234 8.7242 1859667 331.7664  19.3264 10.82419157413667""")):
             io.twoline2rv(good1, good2.replace(' 34', '34 '), wgs72)
 
+    def test_mismatched_lines(self):
+        with self.assertRaisesRegexp(ValueError, re.escape("""Object numbers in lines 1 and 2 do not match""")):
+            io.twoline2rv(good1, bad2, wgs72)
+
 
 good1 = '1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753'
 good2 = '2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667'
+bad2  = '2 00007  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413669'
 
 
 


### PR DESCRIPTION
Here we go. Use Numba jit to accelerate sgp4() and _dspace() if possible.

On my test machine, there is a sub-microsecond overhead in dispatching a function through numba. Depending on the complexity of the function that can turn into a 2-5x reduction in performance for functions like mag(), dot(), cross(). Thus, it is not worth jitting ext.py.

There is also an overhead, on the order of hundreds of milliseconds, to simply importing a module that references a jitted function, even if the compiled code exists in cache.

And you really want to cache the compiled code, since it can take over 30 seconds to compile sgp4. 

Once the code has been compiled, there can be an overhead of several (less than 10) seconds to load the compiled code from cache.

But after all that, computing the positions of geostationary satellites is 8-10x faster if you can take advantage of Numba.
