### PR TITLE
Subclass Satellite and use twoline2rv as its constructor

### DIFF
--- a/sgp4/sat2.py
+++ b/sgp4/sat2.py
@@ -1,0 +1,14 @@
+from sgp4.io import twoline2rv
+from sgp4.model import Satellite
+from sgp4.earth_gravity import wgs72
+
+class Satellite2(Satellite):
+    """
+    Subclass of Satellite that uses the twoline2rv function as a constructor.
+
+    This is useful if you're subclassing Satellite and need to modify the constructor (e.g. attach another attribute)
+    """
+    def __init__(self, longstr1, longstr2, whichconst, afspc_mode=False):
+        _Satellite = twoline2rv(longstr1, longstr2, whichconst, afspc_mode)
+        for attr in vars(_Satellite):
+            setattr(self, attr, vars(_Satellite)[attr])

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -14,6 +14,7 @@ from math import pi, isnan
 from sgp4.earth_gravity import wgs72
 from sgp4.ext import invjday, newtonnu, rv2coe
 from sgp4.propagation import sgp4
+from sgp4.sat2 import Satellite2
 from sgp4 import io
 
 thisdir = os.path.dirname(__file__)
@@ -159,6 +160,15 @@ with an N where each digit should go, followed by the line you provided:
         msg = "Object numbers in lines 1 and 2 do not match"
         with self.assertRaisesRegexp(ValueError, re.escape(msg)):
             io.twoline2rv(good1, bad2, wgs72)
+
+    def test_constructed_sat(self):
+        sat1 = io.twoline2rv(good1, good2, wgs72)
+        sat2 = Satellite2(good1, good2, wgs72)
+        # generate set of test times
+        test_times = [(2000, 6, day, 0, 0, 0) for day in range(26, 31)]
+        for test_time in test_times:
+            # It should use the exact same algorithm - so even the issues with floating point equality shouldn't come up
+            self.assertEqual(sat1.propagate(*test_time), sat2.propagate(*test_time))
 
 
 good1 = '1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753'


### PR DESCRIPTION
I was figuring that this would be helpful if you needed to subclass Satellite and change the __init__, e.g. adding some other property. I've just added a Satellite2 class that subclasses Satellite and pulls all of its attributes from a dummy object generated by twoline2rv. (I imagine Satellite2 isn't a very good name but I couldn't think of anything too descriptive). I figure this keeps it backwards compatible.

I'm going to apologize - I'm a hobby programmer at best, so I'm not really familiar with some of the technologies used (e.g. CI, or how Python manages the source of a package). Nor do I know a lot about astronomy [I'm looking through these packages for a GPS-tracking project]. I've done my best to try to follow the rules, but I apologize if I've broken something, or if this addition isn't very useful.