### PR TITLE
Fix mrt check to return NAN

### DIFF
--- a/sgp4/propagation.py
+++ b/sgp4/propagation.py
@@ -1964,6 +1964,8 @@ def sgp4(satrec, tsince, whichconst=None):
                                  ' the satellite has decayed'.format(mrt))
          satrec.error = 6;
 
+         return false, false
+
      return r, v;
 
 """


### PR DESCRIPTION
When writing tests for the vectorized code, I noticed that this `mrt` check is not returning NAN. I assume that is the intended behavior to align with `tcppver.out`?