### PR TITLE
Added jday_datetime() to convert native `datetime` object into JD.

### DIFF
--- a/sgp4/functions.py
+++ b/sgp4/functions.py
@@ -5,6 +5,11 @@ modules to offer simple date handling, so this small module holds the
 routines instead.
 
 """
+from datetime import datetime
+
+import pytz
+
+
 def jday(year, mon, day, hr, minute, sec):
      """Return two floats that, when added, produce the specified Julian date.
 
@@ -37,3 +42,44 @@ def jday(year, mon, day, hr, minute, sec):
            + 1721013.5)
      fr = (sec + minute * 60.0 + hr * 3600.0) / 86400.0;
      return jd, fr
+
+def jday_datetime(dtime : datetime):
+    """Return two floats that, when added, produce the specified Julian date.
+
+     The first float returned gives the date, while the second float
+     provides an additional offset for the particular hour, minute, and
+     second of that date.  Because the second float is much smaller in
+     magnitude it can, unlike the first float, be accurate down to very
+     small fractions of a second.
+
+     >>> jd, fr = jday(2020, 2, 11, 13, 57, 0)
+     >>> jd
+     2458890.5
+     >>> fr
+     0.58125
+
+     Note that the first float, which gives the moment of midnight that
+     commences the given calendar date, always carries the fraction
+     ``.5`` because Julian dates begin and end at noon.  This made
+     Julian dates more convenient for astronomers in Europe, by making
+     the whole night belong to a single Julian date.
+
+    The input is a native `datetime` object. Timezone  of the input is converted internally to UTC.
+
+     This function is a simple translation to Python of the C++ routine
+     ``jday()`` in Vallado's ``SGP4.cpp``.
+
+    """
+    # Convert to UTC time
+    dtime_utc = dtime.astimezone(pytz.UTC)
+    year = dtime_utc.year
+    mon = dtime_utc.month
+    day = dtime_utc.day
+
+    hr = dtime_utc.hour
+    minute = dtime_utc.minute
+    sec = dtime_utc.second + dtime_utc.microsecond / 1e6
+
+    return jday(year, mon, day, hr, minute, sec)
+
+

--- a/sgp4/functions.py
+++ b/sgp4/functions.py
@@ -5,9 +5,7 @@ modules to offer simple date handling, so this small module holds the
 routines instead.
 
 """
-from datetime import datetime
-
-import pytz
+from datetime import datetime, timezone
 
 
 def jday(year, mon, day, hr, minute, sec):
@@ -64,21 +62,19 @@ def jday_datetime(dtime : datetime):
      Julian dates more convenient for astronomers in Europe, by making
      the whole night belong to a single Julian date.
 
-    The input is a native `datetime` object. Timezone  of the input is converted internally to UTC.
-
-     This function is a simple translation to Python of the C++ routine
-     ``jday()`` in Vallado's ``SGP4.cpp``.
+    The input is a native `datetime` object. Timezone of the input is
+    converted internally to UTC.
 
     """
     # Convert to UTC time
-    dtime_utc = dtime.astimezone(pytz.UTC)
+    dtime_utc = dtime.astimezone(timezone.utc)
     year = dtime_utc.year
     mon = dtime_utc.month
     day = dtime_utc.day
 
     hr = dtime_utc.hour
     minute = dtime_utc.minute
-    sec = dtime_utc.second + dtime_utc.microsecond / 1e6
+    sec = dtime_utc.second + dtime_utc.microsecond * 1e-6
 
     return jday(year, mon, day, hr, minute, sec)
 

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -1,4 +1,5 @@
 """Test suite for SGP4."""
+from sgp4.functions import jday_datetime
 
 try:
     from unittest2 import TestCase, main
@@ -58,6 +59,19 @@ class FunctionTests(TestCase):
         jd, fr = jday(2019, 10, 9, 16, 57, 15)
         self.assertEqual(jd, 2458765.5)
         self.assertAlmostEqual(fr, 0.7064236111111111)
+
+    def test_jday_datetime(self):
+
+        # define local time
+        # UTC equivalent: 2011-11-03 20:05:23+00:00
+        datetime_local = dt.datetime.fromisoformat("2011-11-04T00:05:23+04:00")
+        datetime_utc = datetime_local.astimezone(dt.timezone.utc)
+
+        jd, fr = jday_datetime(datetime_local)
+
+        # jd of this date is 2455868.5 + 0.8370717592592593
+        self.assertEqual(jd, 2455868.5)
+        self.assertAlmostEqual(fr, 0.8370717592592593)
 
 
 class SatelliteObjectTests(object):


### PR DESCRIPTION
Added jday_datetime() to parse native `datetime` object. Checks for timezone and converts the time into UTC. May reqire `pytz` and `datetime` added to requirements.txt