### PR TITLE
Added export TLE functionality to `Satrec`

### DIFF
--- a/sgp4/export.py
+++ b/sgp4/export.py
@@ -1,0 +1,101 @@
+"""
+Export orbit data to a Two-Line-Element representation.
+"""
+from sgp4.io import compute_checksum
+
+from sgp4.model import Satrec
+
+
+def export_tle(satrec):
+    """
+     Generate the TLE for the data in the `Satrec` object.
+
+    Forms the two string lines of the TLE and returns them as a Tuple.
+
+    Parameters
+    ----------
+    satrec : Satrec
+        Object that holds the orbit information
+
+    Returns
+    -------
+    (line1, line2) : (str, str)
+    """
+
+    # Define constants
+    from math import pi
+    deg2rad = pi / 180.0  # 0.0174532925199433
+    xpdotp = 1440.0 / (2.0 * pi)  # 229.1831180523293
+
+    # --------------------- Start generating line 1 ---------------------
+
+    # Build the list by appending successive items
+    line_as_list = ["1 "]
+
+    # Pad the `satnum` entry with zeros
+    if len(str(satrec.satnum)) <= 5:
+        line_as_list.append(str(satrec.satnum).zfill(5))
+
+    # Add classification code (use "U" if empty)
+    line_as_list.append((satrec.classification.strip() or "U") + " ")
+
+    # Add int'l designator and pad to 8 chars
+    line_as_list.append(satrec.intldesg.ljust(8, " ") + " ")
+
+    # Add epoch year and days in YYDDD.DDDDDDDD format
+    line_as_list.append(str(satrec.epochyr).zfill(2) + "{:012.8f}".format(satrec.epochdays) + " ")
+
+    # Add First Time Derivative of the Mean Motion (don't use "+")
+    line_as_list.append("{0: 8.8f}".format(satrec.ndot * (xpdotp * 1440.0)).replace("0", "", 1) + " ")
+
+    # Add Second Time Derivative of Mean Motion (don't use "+")
+    # Multiplication with 10 is a hack to get the exponent right
+    line_as_list.append("{0: 4.4e}".format((satrec.nddot * (xpdotp * 1440.0 * 1440)) * 10).replace(".", "")
+                        .replace("e+00", "-0").replace("e-0", "-") + " ")
+
+    # Add BSTAR
+    # Multiplication with 10 is a hack to get the exponent right
+    line_as_list.append("{0: 4.4e}".format(satrec.bstar * 10).replace(".", "").replace("e+00", "+0").replace("e-0", "-") + " ")
+
+    # Add Ephemeris Type and Element Number
+    line_as_list.append("{} ".format(satrec.ephtype) + str(satrec.elnum).rjust(4, " "))
+
+    # Join all the parts and add the Checksum
+    line1 = ''.join(line_as_list)
+    line1 += str(compute_checksum(line1))
+
+    # --------------------- Start generating line 2 ---------------------
+
+    # Reset the str array
+    line_as_list = ["2 "]
+
+    # Pad the `satnum` entry with zeros
+    if len(str(satrec.satnum)) <= 5:
+        line_as_list.append(str(satrec.satnum).zfill(5) + " ")
+
+    # Add the inclination (deg)
+    line_as_list.append("{0:8.4f}".format(satrec.inclo / deg2rad).rjust(8, " ") + " ")
+
+    # Add the RAAN (deg)
+    line_as_list.append("{0:8.4f}".format(satrec.nodeo / deg2rad).rjust(8, " ") + " ")
+
+    # Add the eccentricity (delete the leading zero an decimal point)
+    line_as_list.append("{0:8.7f}".format(satrec.ecco).replace("0.", "") + " ")
+
+    # Add the Argument of Perigee (deg)
+    line_as_list.append("{0:8.4f}".format(satrec.argpo / deg2rad).rjust(8, " ") + " ")
+
+    # Add the Mean Anomaly (deg)
+    line_as_list.append("{0:8.4f}".format(satrec.mo / deg2rad).rjust(8, " ") + " ")
+
+    # Add the Mean Motion (revs/day)
+    line_as_list.append("{0:11.8f}".format(satrec.no_kozai * xpdotp).rjust(8, " "))
+
+    # Add the rev number at epoch
+    line_as_list.append(str(satrec.revnum).zfill(4))
+
+    # Join all the parts and add the Checksum
+    line2 = ''.join(line_as_list)
+    line2 += str(compute_checksum(line2))
+
+    return line1, line2

--- a/sgp4/export.py
+++ b/sgp4/export.py
@@ -1,10 +1,14 @@
 """
 Export orbit data to a Two-Line-Element representation.
 """
-from sgp4.io import compute_checksum
+from math import pi
 
+from sgp4.io import compute_checksum
 from sgp4.model import Satrec
 
+# Define constants
+_deg2rad = pi / 180.0  # 0.0174532925199433
+_xpdotp = 1440.0 / (2.0 * pi)  # 229.1831180523293
 
 def export_tle(satrec):
     """
@@ -22,80 +26,77 @@ def export_tle(satrec):
     (line1, line2) : (str, str)
     """
 
-    # Define constants
-    from math import pi
-    deg2rad = pi / 180.0  # 0.0174532925199433
-    xpdotp = 1440.0 / (2.0 * pi)  # 229.1831180523293
-
     # --------------------- Start generating line 1 ---------------------
 
     # Build the list by appending successive items
-    line_as_list = ["1 "]
+    pieces = ["1 "]
+    append = pieces.append
 
     # Pad the `satnum` entry with zeros
     if len(str(satrec.satnum)) <= 5:
-        line_as_list.append(str(satrec.satnum).zfill(5))
+        append(str(satrec.satnum).zfill(5))
 
     # Add classification code (use "U" if empty)
-    line_as_list.append((satrec.classification.strip() or "U") + " ")
+    append((satrec.classification.strip() or "U") + " ")
 
     # Add int'l designator and pad to 8 chars
-    line_as_list.append(satrec.intldesg.ljust(8, " ") + " ")
+    append(satrec.intldesg.ljust(8, " ") + " ")
 
     # Add epoch year and days in YYDDD.DDDDDDDD format
-    line_as_list.append(str(satrec.epochyr).zfill(2) + "{:012.8f}".format(satrec.epochdays) + " ")
+    append(str(satrec.epochyr).zfill(2) + "{:012.8f}".format(satrec.epochdays) + " ")
 
     # Add First Time Derivative of the Mean Motion (don't use "+")
-    line_as_list.append("{0: 8.8f}".format(satrec.ndot * (xpdotp * 1440.0)).replace("0", "", 1) + " ")
+    append("{0: 8.8f}".format(satrec.ndot * (_xpdotp * 1440.0)).replace("0", "", 1) + " ")
 
     # Add Second Time Derivative of Mean Motion (don't use "+")
     # Multiplication with 10 is a hack to get the exponent right
-    line_as_list.append("{0: 4.4e}".format((satrec.nddot * (xpdotp * 1440.0 * 1440)) * 10).replace(".", "")
+    append("{0: 4.4e}".format((satrec.nddot * (_xpdotp * 1440.0 * 1440)) * 10).replace(".", "")
                         .replace("e+00", "-0").replace("e-0", "-") + " ")
 
     # Add BSTAR
     # Multiplication with 10 is a hack to get the exponent right
-    line_as_list.append("{0: 4.4e}".format(satrec.bstar * 10).replace(".", "").replace("e+00", "+0").replace("e-0", "-") + " ")
+    append("{0: 4.4e}".format(satrec.bstar * 10).replace(".", "").replace("e+00", "+0").replace("e-0", "-") + " ")
 
     # Add Ephemeris Type and Element Number
-    line_as_list.append("{} ".format(satrec.ephtype) + str(satrec.elnum).rjust(4, " "))
+    append("{} ".format(satrec.ephtype) + str(satrec.elnum).rjust(4, " "))
 
     # Join all the parts and add the Checksum
-    line1 = ''.join(line_as_list)
+    line1 = ''.join(pieces)
     line1 += str(compute_checksum(line1))
 
     # --------------------- Start generating line 2 ---------------------
 
     # Reset the str array
-    line_as_list = ["2 "]
+    pieces = ["2 "]
+    append = pieces.append
 
     # Pad the `satnum` entry with zeros
     if len(str(satrec.satnum)) <= 5:
-        line_as_list.append(str(satrec.satnum).zfill(5) + " ")
+        append(str(satrec.satnum).zfill(5) + " ")
 
     # Add the inclination (deg)
-    line_as_list.append("{0:8.4f}".format(satrec.inclo / deg2rad).rjust(8, " ") + " ")
+    append("{0:8.4f}".format(satrec.inclo / _deg2rad).rjust(8, " ") + " ")
 
     # Add the RAAN (deg)
-    line_as_list.append("{0:8.4f}".format(satrec.nodeo / deg2rad).rjust(8, " ") + " ")
+    append("{0:8.4f}".format(satrec.nodeo / _deg2rad).rjust(8, " ") + " ")
 
     # Add the eccentricity (delete the leading zero an decimal point)
-    line_as_list.append("{0:8.7f}".format(satrec.ecco).replace("0.", "") + " ")
+    append("{0:8.7f}".format(satrec.ecco).replace("0.", "") + " ")
 
     # Add the Argument of Perigee (deg)
-    line_as_list.append("{0:8.4f}".format(satrec.argpo / deg2rad).rjust(8, " ") + " ")
+    append("{0:8.4f}".format(satrec.argpo / _deg2rad).rjust(8, " ") + " ")
 
     # Add the Mean Anomaly (deg)
-    line_as_list.append("{0:8.4f}".format(satrec.mo / deg2rad).rjust(8, " ") + " ")
+    append("{0:8.4f}".format(satrec.mo / _deg2rad).rjust(8, " ") + " ")
 
     # Add the Mean Motion (revs/day)
-    line_as_list.append("{0:11.8f}".format(satrec.no_kozai * xpdotp).rjust(8, " "))
+    append("{0:11.8f}".format(satrec.no_kozai * _xpdotp).rjust(8, " "))
 
     # Add the rev number at epoch
-    line_as_list.append(str(satrec.revnum).zfill(4))
+    append(str(satrec.revnum).zfill(4))
 
     # Join all the parts and add the Checksum
-    line2 = ''.join(line_as_list)
+    line2 = ''.join(pieces)
     line2 += str(compute_checksum(line2))
 
     return line1, line2

--- a/sgp4/model.py
+++ b/sgp4/model.py
@@ -2,7 +2,7 @@
 
 from sgp4.earth_gravity import wgs72old, wgs72, wgs84
 from sgp4.ext import jday
-from sgp4.io import twoline2rv
+from sgp4.io import twoline2rv, compute_checksum
 from sgp4.propagation import sgp4
 
 WGS72OLD = 0
@@ -88,6 +88,90 @@ class Satrec(object):
 
         r.shape = v.shape = len(jd), 3
         return e, r, v
+
+    def export_tle(self):
+        """Generate the TLE for the data in the `Satrec` object.
+
+        Forms the two string lines of the TLE and returns them as a tuple.
+
+         * ``line1``: line1 of the two-line-element set
+         * ``line2``: line2 of the two-line-element set
+        """
+
+        # Define constants
+        from math import pi
+        deg2rad = pi / 180.0  # 0.0174532925199433
+        xpdotp = 1440.0 / (2.0 * pi)  # 229.1831180523293
+
+        # --------------------- Start generating line 1 ---------------------
+
+        # Strings are immutable, so rather than replacing chars, we will build it
+        line1 = "1 "
+
+        # Pad the `satnum` entry with zeros
+        if len(str(self.satnum)) <= 5:
+            line1 += str(self.satnum).zfill(5)
+
+        # Add classification code (use "U" if empty)
+        line1 += (self.classification.strip() or "U") + " "
+
+        # Add int'l designator and pad to 8 chars
+        line1 += self.intldesg.ljust(8, " ") + " "
+
+        # Add epoch year and days in YYDDD.DDDDDDDD format
+        line1 += str(self.epochyr).zfill(2) + f"{self.epochdays:12.8f}" + " "
+
+        # Add First Time Derivative of the Mean Motion (don't use "+")
+        line1 += f"{(self.ndot * (xpdotp * 1440.0)): 8.8f}".replace("0", "", 1) + " "
+
+        # Add Second Time Derivative of Mean Motion (don't use "+")
+        # Multiplication with 10 is a hack to get the exponent right
+        line1 += f"{(self.nddot * (xpdotp * 1440.0 * 1440)) * 10: 4.4e}".replace(".", "") \
+                     .replace("e+00", "-0").replace("e-0", "-") + " "
+
+        # Add BSTAR
+        # Multiplication with 10 is a hack to get the exponent right
+        line1 += f"{self.bstar * 10: 4.4e}".replace(".", "").replace("e+00", "-0").replace("e-0", "-") + " "
+
+        # Add Ephemeris Type and Element Number
+        line1 += f"{self.ephtype} " + str(self.elnum).rjust(4, " ")
+
+        # Add the Checksum
+        line1 += str(compute_checksum(line1))
+
+        # --------------------- Start generating line 2 ---------------------
+
+        line2 = "2 "
+
+        # Pad the `satnum` entry with zeros
+        if len(str(self.satnum)) <= 5:
+            line2 += str(self.satnum).zfill(5) + " "
+
+        # Add the inclination (deg)
+        line2 += f"{self.inclo / deg2rad:8.4f}".rjust(8, " ") + " "
+
+        # Add the RAAN (deg)
+        line2 += f"{self.nodeo / deg2rad:8.4f}".rjust(8, " ") + " "
+
+        # Add the eccentricity (delete the leading zero an decimal point)
+        line2 += f"{self.ecco :8.7f}".replace("0.", "") + " "
+
+        # Add the Argument of Perigee (deg)
+        line2 += f"{self.argpo / deg2rad:8.4f}".rjust(8, " ") + " "
+
+        # Add the Mean Anomaly (deg)
+        line2 += f"{self.mo / deg2rad:8.4f}".rjust(8, " ") + " "
+
+        # Add the Mean Motion (revs/day)
+        line2 += f"{self.no_kozai * xpdotp:11.8f}".rjust(8, " ")
+
+        # Add the rev number at epoch
+        line2 += str(self.revnum).zfill(4)
+
+        # Add the Checksum
+        line2 += str(compute_checksum(line2))
+
+        return line1, line2
 
 class SatrecArray(object):
     """Slow Python-only version of the satellite array."""

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -42,6 +42,16 @@ class FunctionTests(TestCase):
         with open(tlepath) as tlefile:
             tlelines = iter(tlefile.readlines())
 
+        # Skip these lines, known errors
+        # Resulting TLEs are equivalent (same values in the Satrec object), but they are not the same
+        # 25954: BSTAR = 0 results in a negative exp, not positive
+        # 29141: BSTAR = 0.13519 results in a negative exp, not positive
+        # 33333: Checksum error as expected on both lines
+        # 33334: Checksum error as expected on line 1
+        # 33335: Checksum error as expected on line 1
+        expected_errs_line1 = set([25954, 29141, 33333, 33334, 33335])
+        expected_errs_line2 = set([33333, 33335])
+
         for line1 in tlelines:
 
             if not line1.startswith('1'):
@@ -57,21 +67,11 @@ class FunctionTests(TestCase):
             # Generate TLE from satrec
             out_line1, out_line2 = export_tle(satrec)
 
-            # print("file :  " + line1)
-            # print("satrec: " + out_line1)
-            #
-            # print("file :  " + line2)
-            # print("satrec: " + out_line2)
+            print("file :  " + line1)
+            print("satrec: " + out_line1)
 
-            # Skip these lines, known errors
-            # Resulting TLEs are equivalent (same Satrec object) but they are not the same
-            # 25954: BSTAR = 0 results in a negative exp, not positive
-            # 29141: BSTAR = 0.13519 results in a negative exp, not positive
-            # 33333: Checksum error as expected on both lines
-            # 33334: Checksum error as expected on line 1
-            # 33335: Checksum error as expected on line 1
-            expected_errs_line1 = [25954, 29141, 33333, 33334, 33335]
-            expected_errs_line2 = [33333, 33335]
+            print("file :  " + line2)
+            print("satrec: " + out_line2)
 
             if satrec.satnum not in expected_errs_line1:
                 self.assertEqual(out_line1, line1)


### PR DESCRIPTION
Adds "export TLE" functionality to `Satrec`. This enables modification of the TLE and safely exporting it.

See sample code below.

```
from sgp4.model import Satrec

if __name__ == '__main__':
    line1 = "1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753"
    line2 = "2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667"

    # line1 = "1 16925U 86065D   06151.67415771  .02550794 -30915-6  18784-3 0  4486"
    # line2 = "2 16925  62.0906 295.0239 5596327 245.1593  47.9690  4.88511875148616"

    print(line1)
    print(line2)

    satrec = Satrec.twoline2rv(line1, line2)

    new_line1, new_line2 = satrec.export_tle()

    print(new_line1)
    print(new_line2)
```