### PR TITLE
WIP: improve build script; enable openmp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,12 +57,7 @@ if sys.version_info[0] == 3:
             'extension/SGP4.cpp',
             'extension/wrapper.cpp',
         ],
-        **get_compile_args(),
-        # TODO: can we safely figure out how to use a pair of options
-        # like these, adapted to as many platforms as possible, to use
-        # multiple processors when available?
-        # extra_compile_args=['-fopenmp'],
-        # extra_link_args=['-fopenmp'],
+        **get_compile_args()
     ))
 
 setup(name = 'sgp4',


### PR DESCRIPTION
Hi,

I use `sgp4` in some of my projects and realized that the new accelerated wrapper is OpenMP enabled. However, at least for the conda packages, which I usually use, parallelization seems to be inactive.

I noticed in your `setup.py` that the OpenMP associated compiler flag is commented out and that there is a comment, which asks whether there would be a way to find proper compiler arguments for the different platforms. In several of my own Cython projects, I'm doing this based on the `platform` module from the standard lib. This PR is a work-in-progress proposal to add OpenMP support in your `setup.py`. 

Unfortunately, I could not test, if it really works on all platforms, as I have no idea how you build, e.g., your PyPI wheels. It doesn't seem to happen in your `.travis.yml` - do you do that manually?

I should also add, that on my Linux machine, the compiler flag properly works (the warning during build time, that the pragma omp is ignored went away), but testing with a large array does still seem to be bound to a single CPU core. Maybe I'm missing something?

In any case, perhaps we can use this as a base to improve OpenMP handling in sgp4.