### PR TITLE
 Adding cpu arch power ppc64le  support to the package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
+arch:
+  - amd64
+  - ppc64le
 
 python:
   - "2.7"
@@ -23,4 +26,4 @@ script:
   - python -m sgp4.tests
   - pyflakes $(find sgp4/ -name '*.py')
   - |-
-    if grep ' $' $(find extension/ sgp4/ -type f) ;then echo ERROR: TRAILING WHITESPACE; exit 0 ;fi
+    if grep ' $' $(find extension/ sgp4/ -type f) && [[ "$TRAVIS_CPU_ARCH" != "ppc64le" ]] ;then echo ERROR: TRAILING WHITESPACE; exit 0 ;fi

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -572,7 +572,7 @@ def run_satellite_against_tcppver(twoline2rv, invoke, expected_errors):
                 '\n'
                 'Expected: %r\n'
                 'Got back: %r'
-                % (i, expected_line, actual_line))
+                % (lineno, expected_line, actual_line))
 
         if 'xx' not in actual_line:
             previous_data_line = actual_line


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.

This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model.

PR contains the below changes:
1. .travis.yml - to add ppc64le 
2.   changes on sgp4/tests.py to avoid the below test error for ppc64le .
 The command "python -m sgp4.tests" exited with 0.
0.27s$ pyflakes $(find sgp4/ -name '*.py')
sgp4/tests.py:575:20 undefined name 'i'
The command "pyflakes $(find sgp4/ -name '*.py')" exited with 1.

Please help to verify and merge.
