### PR TITLE
Add a note about SGP4 ignoring ndot and nddot

### DIFF
--- a/sgp4/__init__.py
+++ b/sgp4/__init__.py
@@ -352,8 +352,8 @@ satellite object to reset it to those new elements.
 ...     5,               # satnum: Satellite number
 ...     18441.785,       # epoch: days since 1949 December 31 00:00 UT
 ...     2.8098e-05,      # bstar: drag coefficient (/earth radii)
-...     6.969196665e-13, # ndot: ballistic coefficient (revs/day)
-...     0.0,             # nddot: second derivative of mean motion (revs/day^3)
+...     6.969196665e-13, # ndot: ballistic coefficient (ignored)
+...     0.0,             # nddot: second derivative of mean motion (ignored)
 ...     0.1859667,       # ecco: eccentricity
 ...     5.7904160274885, # argpo: argument of perigee (radians)
 ...     0.5980929187319, # inclo: inclination (radians)


### PR DESCRIPTION
If you skip past parts of the package documentation and on to the _Providing your own elements_ section you'll have trouble understanding some of the parameters, particularly the `ndot` and `nddot` ones, which, according to other parts of the documentation, are ignored by SGP4. To make getting started with this API easier for newbies (i.e., me), I've added a small note that these two parameters are ignored by SGP4.
I've also added named parameters which makes it easier to use the example code in projects.