### PR TITLE
Use python 3.7 when running cibuildwheel

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -120,6 +120,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: [3.7]
 
     steps:
       - name: checkout


### PR DESCRIPTION
The macos wheel seems to be missing for python 3.9 in the latest release. I believe that updating cibuildwheel to latest version will fix it.
But, since the latest version [requires python 3.6+][0], and the python github action uses 2.7 by default, we fail to install it (opting in for [version 1.1][1] which is pretty old). So I update the python version cibuildwheel runs in, same as cibuildwheel does itself [in it's own test action][2].

Note: cibuildwheel should build all linux versions in docker, but we may need to add more python versions to build the windows/macos versions if this fails to work (see [this diagram][3]).

[0]: https://pypi.org/project/cibuildwheel/
[1]: https://pypi.org/project/cibuildwheel/1.1.0/#history
[2]: https://github.com/joerick/cibuildwheel/blob/master/.github/workflows/test.yml#L29
[3]: https://github.com/joerick/cibuildwheel/issues/468#issuecomment-754134730