### PR TITLE
Add satnum setter

### DIFF
--- a/sgp4/exporter.py
+++ b/sgp4/exporter.py
@@ -4,7 +4,7 @@ Contributed by Egemen Imre https://github.com/egemenimre
 
 """
 from math import pi
-from sgp4.io import compute_checksum
+from sgp4.io import compute_checksum, _to_alpha5
 from sgp4.conveniences import sat_epoch_datetime
 
 # Define constants
@@ -14,15 +14,20 @@ _xpdotp = 1440.0 / (2.0 * pi)  # 229.1831180523293
 def export_tle(satrec):
     """Generate the TLE for a given `Satrec` object; returns two strings."""
 
+    if satrec.satnum < 99999:
+        # Pad the `satnum` entry with zeros
+        satnum = f'{satrec.satnum:05d}'
+    else:
+        satnum = _to_alpha5(satrec.satnum)
+
     # --------------------- Start generating line 1 ---------------------
 
     # Build the list by appending successive items
     pieces = ["1 "]
     append = pieces.append
 
-    # Pad the `satnum` entry with zeros
-    if len(str(satrec.satnum)) <= 5:
-        append(str(satrec.satnum).zfill(5))
+    # properly formatted satnum
+    append(satnum)
 
     # Add classification code (use "U" if empty)
     classification = getattr(satrec, 'classification', 'U')
@@ -63,9 +68,8 @@ def export_tle(satrec):
     pieces = ["2 "]
     append = pieces.append
 
-    # Pad the `satnum` entry with zeros
-    if len(str(satrec.satnum)) <= 5:
-        append(str(satrec.satnum).zfill(5) + " ")
+    # properly formatted satnum
+    append(satnum + ' ')
 
     # Add the inclination (deg)
     if not 0 <= satrec.inclo <= pi:

--- a/sgp4/io.py
+++ b/sgp4/io.py
@@ -277,3 +277,13 @@ def _alpha5(s):
     n -= c > 'I'
     n -= c > 'O'
     return n * 10000 + int(s[1:])
+
+def _to_alpha5(n):
+    n -= 100000
+    c = ord('A') + n // 10000
+    if c >= ord('I'):
+        c += 1
+    if c >= ord('O'):
+        c += 1
+    return f'{chr(c)}{n%10000:04d}'
+


### PR DESCRIPTION
Fixes #97. I'm sure I missed some finer points, but I ginned up a little set of tests and everything seems to work:

* roundtrip unmodified TLEs
* setting satnum as an int: `123456`
* setting satnum as a string: `"123456"`
* setting satnum as an alpha5: `"C3456"`
* rejecting out-of-range satnums
* rejecting badly formatted alpha5: `"WALDO"`, `"O0000"`
* Exporting TLEs with alpha5
* Loading TLEs with alpha5