### PR TITLE
Update CI and add support for more wheels

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -44,23 +44,23 @@ jobs:
   build_test_dist:
     # Build the distribution in a matrix. Jobs are done in parallel.
     # The formal distro which is uploaded to PyPI will be build on
-    # ubuntu-latest for python 3.9, which is the recent one.
+    # ubuntu-latest for python 3.10, which is the recent one.
     # As in dist build no compilation takes place, we run all tests
     # in not accelerated mode.
 
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 18
+      max-parallel: 15
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup_Python_${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -75,14 +75,14 @@ jobs:
         run: python setup.py sdist
 
       - name: check_metadata
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         run: |
           pip install twine
           twine check dist/*
 
       - name: upload_sdist
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
-        uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/*.tar.gz
@@ -99,51 +99,76 @@ jobs:
         run: python -m sgp4.tests
 
   build_test_wheels:
-    # Building wheels for different OS and python versions. This is done with
-    # the help of 'cibuildwheel' package. It will run on the three different
-    # supported OS each running cibuildwheel on newest python supported as
-    # default on github.
+    # Building wheels for different OS, python and platform versions. This is
+    # done with the help of 'cibuildwheel' package. It will run on all
+    # necessary supported OS (native or emulated), each running cibuildwheel on
+    # actual python (now 3.10).
     # Reference: https://cibuildwheel.readthedocs.io/en/stable/
-    # OS: Windows, Linux and macOS
-    # Python: versions 3.5 - 3.9 (limited by capabilities cibuildwheel)
+    # OS: Windows, Linux, macOS (x64 and M1), ARM64
+    # Python: versions 3.7 - 3.10 in testing
+    # Python: versions 3.6 - 3.10 in build wheels
     # As all build wheels are installed after build, the tests run in
     # accelerated mode only.
-    #
-    # Actually need to address cp39 in CIBW_BUILD explicit, otherwise
-    # only cp36 - cp38 are build. No earlier versions, fits exactly
-    # to actual travis (except aarch64, which is not supported on github)
 
     runs-on: ${{ matrix.os }}
     needs: [build_test_dist]
 
     strategy:
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.7]
-
+        python-version: ['3.10']
+        include:
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
+            
     steps:
+      # Using QEMU for aarch64 emulation 
+      - name: setup QEMU
+        if: matrix.cibw_archs == 'aarch64'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup_Python_${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: install_deps
         run: python -m pip install cibuildwheel
 
-      - name: build_test
+      # unfortunately actions do not have an else statement
+      - name: build_test_aarch64
+        if: matrix.cibw_archs == 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
+          CIBW_ARCHS_LINUX: "aarch64"
+          CIBW_SKIP: '*-musllinux_*'
+          CIBW_BUILD: "cp3*"
           CIBW_BUILD_VERBOSITY: 0
           CIBW_TEST_REQUIRES: numpy
           CIBW_TEST_COMMAND: python -m sgp4.tests
 
+      # unfortunately actions do not have an else statement
+      - name: build_test_normal
+        if: matrix.cibw_archs != 'aarch64'
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_LINUX: "auto"
+          CIBW_SKIP: '*-musllinux_*'
+          CIBW_BUILD: "cp3*"
+          CIBW_BUILD_VERBOSITY: 0
+          CIBW_TEST_REQUIRES: numpy
+          CIBW_TEST_COMMAND: python -m sgp4.tests
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+
       - name: upload_wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheelhouse
           path: wheelhouse
@@ -162,16 +187,16 @@ jobs:
       github.ref == 'refs/heads/release'
 
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
 
     # download dist files
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist
 
     # download wheels
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: wheelhouse
         path: dist


### PR DESCRIPTION
Hi Brandon,

I made some updates for the wheel builds to platforms which were initially not feasible.  

Support Mac M1
Support ARM aarch64
Updates for used actions to recent ones and python runtime to 3.10

In addition I removed python 2.7 support for test (please feel free to add again)
I made some test trials and in my environment and local GitHub fork it went fine and build all wheels.

Hope this helps to get a broader usage (at least as aarch64 was missing and I had several users for which I build separately the wheels manually).

best regards,
Michel