### PR TITLE
correct version number publish action

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -231,7 +231,7 @@ jobs:
     # chosen for the PyPI token.
 
     - name: upload_to_pypi
-      uses: pypa/gh-action-pypi-publish@v1
+      uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
@brandon-rhodes: It seems that publish action does not support just major versions numbers as others, so I choose a dedicated one like in the past.
As I cannot check with the correct credentials, there is the intension on PyPI to move away from User / password to certificates or authorization through tokens. I do not know, when this will be enforced. If so, we have to change the authorization method.
Hope this was a quick fix.