### PR TITLE
Adding build part support for python 3.13 aarch64 wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 15
+      max-parallel: 18
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup_Python_${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -105,8 +105,8 @@ jobs:
 
     # Reference: https://cibuildwheel.readthedocs.io/en/stable/
     # OS: Windows, Linux, macOS (x64 and M1), ARM64
-    # Python: versions 3.7 - 3.12 in testing
-    # Python: versions 3.7 - 3.12 in build wheels
+    # Python: versions 3.7 - 3.13 in testing
+    # Python: versions 3.7 - 3.13 in build wheels
     # As all build wheels are installed after build, the tests run in
     # accelerated mode only.
 
@@ -119,7 +119,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ['3.12']
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cibw_archs: "aarch64"
             python-version: '3.12'
 
@@ -144,7 +144,7 @@ jobs:
 
       # unfortunately actions do not have an else statement
       # and I have to split builds due to numpy pinning
-      - name: build_test_aarch64_until_p39
+      - name: build_test_aarch64_to_p39
         if: matrix.cibw_archs == 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -155,7 +155,7 @@ jobs:
           CIBW_TEST_REQUIRES: numpy==1.21.1
           CIBW_TEST_COMMAND: python -m sgp4.tests
 
-      - name: build_test_normal_until_p39
+      - name: build_test_normal_to_p39
         if: matrix.cibw_archs != 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -168,7 +168,7 @@ jobs:
           CIBW_TEST_COMMAND: python -m sgp4.tests
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
-      - name: build_test_aarch64_from_p310
+      - name: build_test_aarch64_from_p310_to_p312
         if: matrix.cibw_archs == 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -179,7 +179,7 @@ jobs:
           CIBW_TEST_REQUIRES: numpy==1.26.1
           CIBW_TEST_COMMAND: python -m sgp4.tests
 
-      - name: build_test_normal_from_p310
+      - name: build_test_normal_from_p310_to_p312
         if: matrix.cibw_archs != 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -189,6 +189,30 @@ jobs:
           CIBW_BUILD: "cp310-* cp311-* cp312-*"
           CIBW_BUILD_VERBOSITY: 0
           CIBW_TEST_REQUIRES: numpy==1.26.1
+          CIBW_TEST_COMMAND: python -m sgp4.tests
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+
+      - name: build_test_aarch64_from_p313
+        if: matrix.cibw_archs == 'aarch64'
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_LINUX: "aarch64"
+          CIBW_SKIP: '*-musllinux_*'
+          CIBW_BUILD: "cp313-*"
+          CIBW_BUILD_VERBOSITY: 0
+          CIBW_TEST_REQUIRES: numpy==2.2.3
+          CIBW_TEST_COMMAND: python -m sgp4.tests
+
+      - name: build_test_normal_from_p313
+        if: matrix.cibw_archs != 'aarch64'
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_SKIP: '*-musllinux_*'
+          CIBW_BUILD: "cp313"
+          CIBW_BUILD_VERBOSITY: 0
+          CIBW_TEST_REQUIRES: numpy==2.2.3
           CIBW_TEST_COMMAND: python -m sgp4.tests
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
 
@@ -215,7 +239,7 @@ jobs:
       github.ref == 'refs/heads/release'
 
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
 
     # download dist files
     - uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ['3.12']
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             cibw_archs: "aarch64"
             python-version: '3.12'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_SKIP: '*-musllinux_*'
-          CIBW_BUILD: "cp313"
+          CIBW_BUILD: "cp313-*"
           CIBW_BUILD_VERBOSITY: 0
           CIBW_TEST_REQUIRES: numpy==2.2.3
           CIBW_TEST_COMMAND: python -m sgp4.tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ on:
 
 jobs:
   # This action is split into three jobs:
-  # - Building the distribution linting and testing without acceleration
-  # - Building the wheels for the distribution and testing with acceleration
-  # - Uploading the artifacts to PyPI package if branch is release
+  # - Building the distribution linting and testing without acceleration.
+  # - Building the wheels for the distribution and testing with acceleration.
+  # - Uploading the artifacts to PyPI package if branch is release.
   # The uploading job needs all tests to be finished without error.
 
   build_test_dist:

--- a/pure_python/setup.py
+++ b/pure_python/setup.py
@@ -1,0 +1,55 @@
+from distutils.core import setup
+
+# Place this `setup.py` at the root of the project to build and
+# distribute a pure-Python version of SGP4.
+
+# Read the package's docstring and "__version__" without importing it.
+path = 'sgp4/__init__.py'
+with open(path, 'rb') as f:
+    text = f.read().decode('utf-8')
+text = text.replace('-*- coding: utf-8 -*-', '')  # for Python 2.7
+
+namespace = {}
+eval(compile(text, path, 'exec'), namespace)
+
+version = namespace['__version__']
+description, long_description = namespace['__doc__'].split('\n', 1)
+
+# Avoid "`long_description` has syntax errors in markup" from extra
+# whitespace that somehow creeps in.
+description = description.strip()
+long_description = """\
+This distribution provides the `sgp4 package <https://pypi.org/project/sgp4/>`_
+for computing Earth satellite positions, but without making any attempt to
+compile and install the accelerated C++ version of the algorithm.  Instead,
+it is implemented in (rather slow) pure Python code.
+"""
+
+setup(
+    name = 'sgp4_pure_python',
+    version = version,
+    description = description,
+    long_description = long_description,
+    long_description_content_type = 'text/x-rst',
+    license = 'MIT',
+    author = 'Brandon Rhodes',
+    author_email = 'brandon@rhodesmill.org',
+    url = 'https://github.com/brandon-rhodes/python-sgp4',
+    classifiers = [
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Topic :: Scientific/Engineering :: Astronomy',
+    ],
+    packages = ['sgp4'],
+    package_data = {'sgp4': ['SGP4-VER.TLE', 'sample*', 'tcppver.out']},
+    provides = ['sgp4'],
+)


### PR DESCRIPTION
Hi Brandon,
I was already on the way adding the necessary topics for the ci with python 3.13. You already started doing so. The pull request adds the missing parts.

- aarch64 needs again a split between python <= 3.12 and 3.13 ongoing due to the fact that the related numpy versions are not available for python 3.13

Looking forward to your comments. And hopefully you were able to publish a python 3.13 compatible version.

Michel

PS: I'm not happy with splitting the build even more, but I did not get a good solution otherwise -> still to need learning on this.