### PR TITLE
fix breaking change in artifact handling v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,7 @@ jobs:
       # testing and checking the metadata.
 
       - name: install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install numpy pyflakes setuptools twine
+        run: pip install numpy pyflakes setuptools twine
 
       - name: build distro
         run: python setup.py sdist
@@ -85,7 +83,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: artifact-dist-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist/*.tar.gz
 
       - name: rename file
@@ -137,7 +135,7 @@ jobs:
       - name: upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheelhouse-${{ matrix.os }}
+          name: artifact-wheelhouse-${{ matrix.os }}
           path: wheelhouse
 
   upload_to_pypi:
@@ -156,11 +154,11 @@ jobs:
     steps:
     - uses: actions/setup-python@v5
 
-    # Download dist files and wheels from the artifacts
     - uses: actions/download-artifact@v4
       with:
-        name: artifacts
         path: dist
+        pattern: artifact-*
+        merge-multiple: true
 
     # For the activation of the PyPI index, please add a secret token from
     # PyPI to the GitHub repo, give it a name and replace in the password


### PR DESCRIPTION
@brandon-rhodes,
Attached the fix for the broken part in artefactory workflow. I did try to test is as far I could go (I made a release branch like yours to see if the workflow is running without problems. I could not check the upload itself, but the files are now present in dist folder. So it should run through now.
I also removed the upgrade pip installation as it does not remove the single warning in workflow. This happens during the python-setup workflow, which is imported.
Again sorry for the missing changes I forgot.
Michel