### PR TITLE
BLD: avoid deprecation warnings from setuptools when building on Python 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       # testing and checking the metadata.
 
       - name: install dependencies
-        run: pip install numpy pyflakes setuptools twine
+        run: pip install --upgrade numpy pyflakes setuptools>=77.0.1 twine
 
       - name: build distro
         run: python setup.py sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = [
+    "setuptools>=38.6.0", # for long_description_content_type
+    "setuptools>=77.0.1 ; python_version>='3'",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+# keep in sync with setup_kwargs for Python 2
+name = "sgp4"
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+requires-python = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5,!=3.6,!=3.7,!=3.8,!=3.9"
+dynamic = ["version", "description", "authors", "dependencies", "classifiers"]

--- a/setup.py
+++ b/setup.py
@@ -59,25 +59,30 @@ description, long_description = namespace['__doc__'].split('\n', 1)
 description = description.strip()
 long_description = long_description.strip() + '\n'
 
+if sys.version_info[0] == 2:
+    # keep in sync with the [project] table from pyproject.toml
+    setup_kwargs = {
+        "name": "sgp4",
+        "long_description": long_description,
+        "long_description_content_type": 'text/markdown',
+        "license": 'MIT',
+    }
+else:
+    # equivalent metadata lives in pyproject.toml
+    setup_kwargs = {}
+
 setup(
-    name = 'sgp4',
     version = version,
     description = description,
-    long_description = long_description,
-    long_description_content_type = 'text/x-rst',
-    license = 'MIT',
     author = 'Brandon Rhodes',
     author_email = 'brandon@rhodesmill.org',
     url = 'https://github.com/brandon-rhodes/python-sgp4',
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
@@ -89,4 +94,5 @@ setup(
     package_data = {'sgp4': ['SGP4-VER.TLE', 'sample*', 'tcppver.out']},
     provides = ['sgp4'],
     ext_modules = ext_modules,
+    **setup_kwargs,
 )


### PR DESCRIPTION
This addopts the standard license metadata format defined in https://peps.python.org/pep-0639/, which recent versions of setuptools have been pressing users to migrate to, since it clashes directly with their equivalent schema.
I tried to preserve Python 2 compat while keeping duplications to a minimum.