### PR TITLE
RFC: restrict usage of `PyUnicode_*` functions to the Limited API subset

### DIFF
--- a/extension/wrapper.cpp
+++ b/extension/wrapper.cpp
@@ -424,7 +424,7 @@ get_intldesg(SatrecObject *self, void *closure)
 static int
 set_intldesg(SatrecObject *self, PyObject *value, void *closure)
 {
-    const char *s = PyUnicode_AsUTF8(value);
+    const char *s = PyUnicode_AsUTF8AndSize(value, NULL);
     if (!s)
         return -1;
     strncpy(self->satrec.intldesg, s, 10);
@@ -460,7 +460,7 @@ get_satnum_str(SatrecObject *self, void *closure)
 static int
 set_satnum_str(SatrecObject *self, PyObject *value, void *closure)
 {
-    const char *s = PyUnicode_AsUTF8(value);
+    const char *s = PyUnicode_AsUTF8AndSize(value, NULL);
     if (!s)
         return -1;
     strncpy(self->satrec.satnum, s, 5);


### PR DESCRIPTION
needed for #151

This should be exactly equivalent. See [docs](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8)
