### PR TITLE
RFC: treat `PyTypeObject` as an opaque struct for Limited API compliance

### DIFF
--- a/extension/wrapper.cpp
+++ b/extension/wrapper.cpp
@@ -124,7 +124,8 @@ Satrec_twoline2rv(PyTypeObject *cls, PyObject *args)
     line2[68] = '\0';
 
     /* Allocate the new object. */
-    SatrecObject *self = (SatrecObject*) cls->tp_alloc(cls, 0);
+    allocfunc alloc_func = (allocfunc)PyType_GetSlot(cls, Py_tp_alloc);
+    SatrecObject *self = (SatrecObject*)alloc_func(cls, 0);
     if (!self)
         return NULL;
 
@@ -504,7 +505,9 @@ SatrecArray_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (length == -1)
         return NULL;
 
-    return type->tp_alloc(type, length);
+    allocfunc alloc_func = (allocfunc)PyType_GetSlot(type, Py_tp_alloc);
+    PyObject *new_satrec = alloc_func(type, length);
+    return new_satrec;
 }
 
 


### PR DESCRIPTION
needed for #151
based off #153

This one doesn't compile yet, but the good news is that the errors are identical wether I force abi3 or not.

```
extension/wrapper.cpp:124:15: error: cannot initialize a variable of type 'allocfunc' (aka '_object *(*)(_typeobject *, long)') with an rvalue of type 'void *'
  124 |     allocfunc alloc_func = PyType_GetSlot(cls, Py_tp_alloc);
      |               ^            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
extension/wrapper.cpp:514:15: error: cannot initialize a variable of type 'allocfunc' (aka '_object *(*)(_typeobject *, long)') with an rvalue of type 'void *'
  514 |     allocfunc alloc_func = PyType_GetSlot(type, Py_tp_alloc);
      |               ^            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```
