### PR TITLE
MNT: move cibw's configuration to TOML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,6 @@ jobs:
         uses: pypa/cibuildwheel@v3.3.1
         env:
           PYTHON_SGP4_COMPILE: always
-          # if adding python 3.15, just add cp315-*
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
-          CIBW_BUILD_VERBOSITY: 0
-          CIBW_SKIP: '*-musllinux_*'
-          CIBW_TEST_REQUIRES: numpy
-          CIBW_TEST_COMMAND: python -m sgp4.tests
 
       - name: upload wheels
         uses: actions/upload-artifact@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,21 @@ name = "sgp4"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
-requires-python = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5,!=3.6,!=3.7,!=3.8,!=3.9"
+requires-python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,!=3.8.*,!=3.9.*"
 dynamic = ["version", "description", "authors", "dependencies", "classifiers"]
+
+[dependency-groups]
+dev = [
+    "numpy>=1.21.2",
+]
+
+[tool.cibuildwheel]
+build-verbosity = 0
+skip = [
+    "*-musllinux_*", # not sure there's a good reason for this anymore ?
+    "cp314t-*",
+]
+test-groups = ["dev"]
+test-command = [
+    "python -m unittest sgp4.tests",
+]


### PR DESCRIPTION
Based off #155 which introduced `pyproject.toml`
Incidentally also includes #153
