### PR TITLE
DEP: upgrade and pin github action dependencies to immutable hash forms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup_Python_${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -85,7 +85,7 @@ jobs:
       - name: upload distro
         # when adding python 3.15, move distro version to 3.15 as well
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-dist-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist/*.tar.gz
@@ -121,9 +121,9 @@ jobs:
         os: [windows-latest, ubuntu-latest, ubuntu-24.04-arm,  macos-latest, macos-15-intel]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build wheels python 3.10 - 3.14
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         env:
           PYTHON_SGP4_COMPILE: always
           # if adding python 3.15, just add cp315-*
@@ -134,7 +134,7 @@ jobs:
           CIBW_TEST_COMMAND: python -m sgp4.tests
 
       - name: upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-wheelhouse-${{ matrix.os }}
           path: wheelhouse
@@ -153,9 +153,9 @@ jobs:
       github.ref == 'refs/heads/release'
 
     steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
-    - uses: actions/download-artifact@v7
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: dist
         pattern: artifact-*
@@ -167,7 +167,7 @@ jobs:
     # chosen for the PyPI token.
 
     - name: upload_to_pypi
-      uses: pypa/gh-action-pypi-publish@v1.13.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
My starting point was a warning on CI, related to `actions/upload-artifact@v4` using a [deprecated version of node](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), and thus, in need for an upgrade. I used `pinact init + pinact run --update` to upgrade *all* GHA dependencies, which also comes with the benefit of pinning them to immutable git hashes, replacing mutable (sometimes intentionally moving) git tags which consistute a security risk as they can be leveraged to create supply chain attacks.