### PR TITLE
WHL: add musllinux to the build matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dev = [
 [tool.cibuildwheel]
 build-verbosity = 0
 skip = [
-    "*-musllinux_*", # not sure there's a good reason for this anymore ?
     "cp314t-*",
 ]
 test-groups = ["dev"]


### PR DESCRIPTION
a quick follow up to #159, as discussed at https://github.com/brandon-rhodes/python-sgp4/pull/159#discussion_r2924253570