### PR TITLE
Handle empty arrays in pure Python API

### DIFF
--- a/sgp4/model.py
+++ b/sgp4/model.py
@@ -126,22 +126,17 @@ class Satrec(object):
 
         """
         # Import NumPy the first time sgp4_array() is called.
-        array = self.array
-        if array is None:
-            from numpy import array
-            Satrec.array = array
+        from numpy import zeros
 
-        results = []
-        z = list(zip(jd, fr))
-        for jd_i, fr_i in z:
-            results.append(self.sgp4(jd_i, fr_i))
-        elist, rlist, vlist = zip(*results)
+        jdlen = len(jd)
+        e = zeros(jdlen, 'uint8')
+        r = zeros((jdlen, 3), 'float64')
+        v = zeros((jdlen, 3), 'float64')
 
-        e = array(elist)
-        r = array(rlist)
-        v = array(vlist)
+        z = zip(jd, fr)
+        for i, (jd_i, fr_i) in enumerate(z):
+            e[i], r[i], v[i] = self.sgp4(jd_i, fr_i)
 
-        r.shape = v.shape = len(jd), 3
         return e, r, v
 
 class SatrecArray(object):
@@ -171,21 +166,18 @@ class SatrecArray(object):
         * ``v``: (dx,dy,dz) velocity vector in kilometers per second.
 
         """
-        results = []
-        z = list(zip(jd, fr))
-        for satrec in self._satrecs:
-            for jd_i, fr_i in z:
-                results.append(satrec.sgp4(jd_i, fr_i))
-        elist, rlist, vlist = zip(*results)
-
-        e = self.array(elist)
-        r = self.array(rlist)
-        v = self.array(vlist)
+        from numpy import zeros
 
         jdlen = len(jd)
         mylen = len(self._satrecs)
-        e.shape = (mylen, jdlen)
-        r.shape = v.shape = (mylen, jdlen, 3)
+        e = zeros((mylen, jdlen), 'uint8')
+        r = zeros((mylen, jdlen, 3), 'float64')
+        v = zeros((mylen, jdlen, 3), 'float64')
+
+        z = list(zip(jd, fr))
+        for i, satrec in enumerate(self._satrecs):
+            for j, (jd_i, fr_i) in enumerate(z):
+                e[i, j], r[i, j], v[i, j] = satrec.sgp4(jd_i, fr_i)
 
         return e, r, v
 

--- a/sgp4/model.py
+++ b/sgp4/model.py
@@ -125,7 +125,10 @@ class Satrec(object):
         * ``v``: velocity vectors in kilometers per second.
 
         """
-        # Import NumPy the first time sgp4_array() is called.
+        if len(jd) != len(fr):
+            raise ValueError('jd and fr must have the same length')
+
+        # Import NumPy lazily.
         from numpy import zeros
 
         jdlen = len(jd)
@@ -166,6 +169,9 @@ class SatrecArray(object):
         * ``v``: (dx,dy,dz) velocity vector in kilometers per second.
 
         """
+        if len(jd) != len(fr):
+            raise ValueError('jd and fr must have the same length')
+
         from numpy import zeros
 
         jdlen = len(jd)

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -133,6 +133,39 @@ def test_whether_array_logic_writes_nan_values_to_correct_row():
     assert np.isnan(r).tolist() == [[False, False, False], [True, True, True]]
     assert np.isnan(v).tolist() == [[False, False, False], [True, True, True]]
 
+def test_satrec_array_logic_accepts_empty_arrays():
+    skip_under_python2()
+
+    import numpy as np
+
+    sat = Satrec.twoline2rv(LINE1, LINE2)
+    jd = np.array([])
+    fr = np.array([])
+    e, r, v = sat.sgp4_array(jd, fr)
+    assert e.dtype == np.uint8
+    assert r.dtype == np.float64
+    assert v.dtype == np.float64
+    assert e.shape == (0,)
+    assert r.shape == (0, 3)
+    assert v.shape == (0, 3)
+
+def test_satrecarray_logic_accepts_empty_arrays():
+    skip_under_python2()
+
+    import numpy as np
+
+    sat = Satrec.twoline2rv(LINE1, LINE2)
+    sat_array = api.SatrecArray([sat])
+    jd = np.array([])
+    fr = np.array([])
+    e, r, v = sat_array.sgp4(jd, fr)
+    assert e.dtype == np.uint8
+    assert r.dtype == np.float64
+    assert v.dtype == np.float64
+    assert e.shape == (1, 0)
+    assert r.shape == (1, 0, 3)
+    assert v.shape == (1, 0, 3)
+
 # ------------------------------------------------------------------------
 #                 Other Officially Supported Routines
 #

--- a/sgp4/tests.py
+++ b/sgp4/tests.py
@@ -166,6 +166,17 @@ def test_satrecarray_logic_accepts_empty_arrays():
     assert r.shape == (1, 0, 3)
     assert v.shape == (1, 0, 3)
 
+def test_array_logic_rejects_arrays_of_different_lengths():
+    skip_under_python2()
+
+    import numpy as np
+
+    sat = Satrec.twoline2rv(LINE1, LINE2)
+    jd = np.array([2458827.5])
+    fr = np.array([])
+    assertRaises(ValueError, sat.sgp4_array, jd, fr)
+    assertRaises(ValueError, api.SatrecArray([sat]).sgp4, jd, fr)
+
 # ------------------------------------------------------------------------
 #                 Other Officially Supported Routines
 #


### PR DESCRIPTION
Fixes #164.

The pure-Python `sgp4_array()` path now preallocates output arrays before looping, so zero-length inputs return the same shapes and dtypes as the accelerated implementation.

Also adds regression coverage for `Satrec.sgp4_array()` and `SatrecArray.sgp4()`.

Tested with:
- `python3 -m unittest sgp4.tests`
